### PR TITLE
Suggested change to getTotalSlides

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3006,10 +3006,9 @@
 	/**
 	 * Retrieves the total number of slides in this presentation.
 	 */
-	function getTotalSlides() {
-
-		return dom.wrapper.querySelectorAll( SLIDES_SELECTOR + ':not(.stack)' ).length;
-
+	function getTotalSlides(config) {
+		var selector = config.vertical ? SLIDES_SELECTOR : HORIZONTAL_SLIDES_SELECTOR;
+		return dom.wrapper.querySelectorAll( selector ).length;
 	}
 
 	/**


### PR DESCRIPTION
The getTotalSlides method currently returns all slides (including vertical) as the method appears to be using a deprecated class in the quesry selector ":not(.stack)". I would suggest that this could be controlled by an argument to determine if all slides should be returned, or at the very least the selector should be changed to "HORIZONTAL_SLIDES_SELECTOR" so that a current page number can be evaluated against the total slides to determine if the user is at the end of the presentation.